### PR TITLE
Add profile description escaping to prevent XSS

### DIFF
--- a/app/Http/Requests/UpdateProfileRequest.php
+++ b/app/Http/Requests/UpdateProfileRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Rules\CurrentPassword;
 use App\User;
 use Illuminate\Foundation\Http\FormRequest;
+use Stevebauman\Purify\Facades\Purify;
 
 class UpdateProfileRequest extends FormRequest
 {
@@ -43,5 +44,22 @@ class UpdateProfileRequest extends FormRequest
             ];
         }
         return [];
+    }
+
+     /**
+     * Extend the default getValidatorInstance method
+     * so description field can be escaped
+     *
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    protected function getValidatorInstance()
+    {
+        $request = $this->toArray();
+        if (array_key_exists('description', $request)) {
+            $description = $request["description"];
+            $escaped_description = Purify::clean($description);
+            $this->merge(array('description' => $escaped_description));
+        }
+        return parent::getValidatorInstance();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
+        "ext-fileinfo": "*",
         "ext-zip": "*",
         "barryvdh/laravel-dompdf": "^0.8.5",
         "fideloper/proxy": "^4.0",
@@ -19,10 +20,10 @@
         "laravel/tinker": "^1.0",
         "laravelcollective/html": "^6.0",
         "spatie/laravel-permission": "^3.2",
+        "stevebauman/purify": "^4.0",
         "yajra/laravel-datatables-buttons": "^4.8",
         "yajra/laravel-datatables-html": "^4.19",
-        "yajra/laravel-datatables-oracle": "~9.0",
-        "ext-fileinfo": "*"
+        "yajra/laravel-datatables-oracle": "~9.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c0e36b48a784b1199ba31f2ea5410b9",
+    "content-hash": "5e75822ce6d1786f50be75e581b98f0e",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -449,6 +449,56 @@
             "time": "2019-03-17T18:48:37+00:00"
         },
         {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "dev-master#72de02a7b80c6bb8864ef9bf66d41d2f58f826bd"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "time": "2020-06-29T00:56:53+00:00"
+        },
+        {
             "name": "fideloper/proxy",
             "version": "4.2.1",
             "source": {
@@ -800,6 +850,7 @@
                     "email": "jakub.onderka@gmail.com"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-color",
             "time": "2018-09-29T17:23:10+00:00"
         },
         {
@@ -846,6 +897,7 @@
                 }
             ],
             "description": "Highlight PHP code in terminal",
+            "abandoned": "php-parallel-lint/php-console-highlighter",
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
@@ -2530,6 +2582,67 @@
                 "spatie"
             ],
             "time": "2019-10-16T19:25:56+00:00"
+        },
+        {
+            "name": "stevebauman/purify",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stevebauman/purify.git",
+                "reference": "823ad75e35f94139ca99701dcbdab9851ad52105"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stevebauman/purify/zipball/823ad75e35f94139ca99701dcbdab9851ad52105",
+                "reference": "823ad75e35f94139ca99701dcbdab9851ad52105",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.9.0",
+                "illuminate/support": "~5.5|~6.0|~7.0|~8.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "orchestra/testbench": "~3.7",
+                "phpunit/phpunit": "~7.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Stevebauman\\Purify\\PurifyServiceProvider"
+                    ],
+                    "aliases": {
+                        "Purify": "Stevebauman\\Purify\\Facades\\Purify"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stevebauman\\Purify\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Steve Bauman",
+                    "email": "steven_bauman@outlook.com"
+                }
+            ],
+            "description": "An HTML Purifier / Sanitizer for Laravel",
+            "keywords": [
+                "Purifier",
+                "clean",
+                "cleaner",
+                "html",
+                "laravel",
+                "purification",
+                "purify"
+            ],
+            "time": "2021-01-07T22:44:04+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -7262,8 +7375,9 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.2",
-        "ext-zip": "*",
-        "ext-fileinfo": "*"
+        "ext-fileinfo": "*",
+        "ext-zip": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/config/purify.php
+++ b/config/purify.php
@@ -1,0 +1,135 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Settings
+    |--------------------------------------------------------------------------
+    |
+    | The configuration settings array is passed directly to HTMLPurifier.
+    |
+    | Feel free to add / remove / customize these attributes as you wish.
+    |
+    | Documentation: http://htmlpurifier.org/live/configdoc/plain.html
+    |
+    */
+
+    'settings' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Core.Encoding
+        |--------------------------------------------------------------------------
+        |
+        | The encoding to convert input to.
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#Core.Encoding
+        |
+        */
+
+        'Core.Encoding' => 'utf-8',
+
+        /*
+        |--------------------------------------------------------------------------
+        | Core.SerializerPath
+        |--------------------------------------------------------------------------
+        |
+        | The HTML purifier serializer cache path.
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#Cache.SerializerPath
+        |
+        */
+
+        'Cache.SerializerPath' => storage_path('app/purify'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | HTML.Doctype
+        |--------------------------------------------------------------------------
+        |
+        | Doctype to use during filtering.
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#HTML.Doctype
+        |
+        */
+
+        'HTML.Doctype' => 'XHTML 1.0 Strict',
+
+        /*
+        |--------------------------------------------------------------------------
+        | HTML.Allowed
+        |--------------------------------------------------------------------------
+        |
+        | The allowed HTML Elements with their allowed attributes.
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#HTML.Allowed
+        |
+        */
+
+        'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span,img[width|height|alt|src]',
+
+        /*
+        |--------------------------------------------------------------------------
+        | HTML.ForbiddenElements
+        |--------------------------------------------------------------------------
+        |
+        | The forbidden HTML elements. Elements that are listed in
+        | this string will be removed, however their content will remain.
+        |
+        | For example if 'p' is inside the string, the string: '<p>Test</p>',
+        |
+        | Will be cleaned to: 'Test'
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#HTML.ForbiddenElements
+        |
+        */
+
+        'HTML.ForbiddenElements' => '',
+
+        /*
+        |--------------------------------------------------------------------------
+        | CSS.AllowedProperties
+        |--------------------------------------------------------------------------
+        |
+        | The Allowed CSS properties.
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#CSS.AllowedProperties
+        |
+        */
+
+        'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
+
+        /*
+        |--------------------------------------------------------------------------
+        | AutoFormat.AutoParagraph
+        |--------------------------------------------------------------------------
+        |
+        | The Allowed CSS properties.
+        |
+        | This directive turns on auto-paragraphing, where double
+        | newlines are converted in to paragraphs whenever possible.
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#AutoFormat.AutoParagraph
+        |
+        */
+
+        'AutoFormat.AutoParagraph' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | AutoFormat.RemoveEmpty
+        |--------------------------------------------------------------------------
+        |
+        | When enabled, HTML Purifier will attempt to remove empty
+        | elements that contribute no semantic information to the document.
+        |
+        | http://htmlpurifier.org/live/configdoc/plain.html#AutoFormat.RemoveEmpty
+        |
+        */
+
+        'AutoFormat.RemoveEmpty' => false,
+
+    ],
+
+];

--- a/storage/app/.gitignore
+++ b/storage/app/.gitignore
@@ -1,3 +1,4 @@
 *
 !public/
 !.gitignore
+!purify/

--- a/storage/app/purify/.gitignore
+++ b/storage/app/purify/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://huntr.dev/bounties/2-other-digidocu/

### ⚙️ Description *

DigiDocu is rendering the description field in the admin's users page without escaping it. A WYSIWYG editor is provided to the users for the profile description which itself has a built-in sanitizer. The user can bypass the WYSIWYG's default sanitizer by intercepting the request (using Burp Suite for instance) and insert some malicious XSS payload. Our fix is to sanitize the HTML before inserting it into the database.

### 💻 Technical Description *

We are using [stevebauman's purify](https://github.com/stevebauman/purify) library which is a wrapper around [ezyang's htmlpurifier](https://github.com/ezyang/htmlpurifier) which is a famous standards-compliant HTML filter library.
We replace the description input with the sanitized version before inserting it into the database
```php 
    // app/Http/Requests/UpdateProfileRequest.php
    /**
     * Extend the default getValidatorInstance method
     * so description field can be escaped
     *
     * @return \Illuminate\Contracts\Validation\Validator
     */
    protected function getValidatorInstance()
    {
        $request = $this->toArray(); // extract all inputs
        if (array_key_exists('description', $request)) {
            $description = $request["description"]; // get description input
            $escaped_description = Purify::clean($description); // escape the data
            $this->merge(array('description' => $escaped_description)); // replace the old data with the new escaped one
        }
        return parent::getValidatorInstance();
    }
```
### 🐛 Proof of Concept (PoC) *

User _test_ is editing his profile:

![image](https://user-images.githubusercontent.com/59918011/114288173-eee00d00-9a64-11eb-9177-54c933519bc8.png)

User _test_ intercepts the request using Burp Suite:

![image](https://user-images.githubusercontent.com/59918011/114288180-07502780-9a65-11eb-8aa7-b32f6b1fb8dd.png)

User _test_ adds his XSS payload to the description input:

![image](https://user-images.githubusercontent.com/59918011/114288199-28187d00-9a65-11eb-8244-d1e81922a090.png)

Admin _super_ visits _test_'s profile, XSS payload gets executed:

![image](https://user-images.githubusercontent.com/59918011/114288227-8c3b4100-9a65-11eb-9973-1356fc1ee674.png)

### 🔥 Proof of Fix (PoF) *

User _test_ is editing his profile:

![image](https://user-images.githubusercontent.com/59918011/114288243-cefd1900-9a65-11eb-90eb-5821b2810a1e.png)

User _test_ intercepts the request using Burp Suite and adds his XSS payload to the description input:

![image](https://user-images.githubusercontent.com/59918011/114288251-ee944180-9a65-11eb-864c-9b4c26176cbb.png)

Admin _super_ visits _test_'s profile, the `<img/>` element is rendered but the XSS payload is not executed:

![image](https://user-images.githubusercontent.com/59918011/114288277-27341b00-9a66-11eb-895f-523291584999.png)

The HTML element is sanitized:

![image](https://user-images.githubusercontent.com/59918011/114288295-521e6f00-9a66-11eb-99bd-5ce38848b2cf.png)

### 👍 User Acceptance Testing (UAT)

There is no unit testing in this project but the feature in question (the WYSIWYG editor) is still working and the HTML is being rendered properly.
